### PR TITLE
timestamp

### DIFF
--- a/schema/video.schema.json
+++ b/schema/video.schema.json
@@ -38,8 +38,8 @@
           },
           "original_time": {
             "type": "string",
-            "description": "Original timestamp from comment in format HH:MM:SS, H:MM:SS or MM:SS",
-            "pattern": "^([0-9]{1,2}:)?[0-5][0-9]:[0-5][0-9]$"
+            "description": "Original timestamp from comment in format HH:MM:SS, H:MM:SS, MM:SS, or M:SS",
+            "pattern": "^([0-9]{1,2}:)?[0-5]?[0-9]:[0-5][0-9]$"
           },
           "song_id": {
             "type": "string",

--- a/scripts/__tests__/unit/hasZeroTimestamp.test.js
+++ b/scripts/__tests__/unit/hasZeroTimestamp.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { hasZeroTimestamp } from '../../updateVideoData.js';
+
+describe('hasZeroTimestamp', () => {
+  it('returns true when timestamps include 0:00', () => {
+    const timestamps = [
+      { time: 0, original_time: '0:00' },
+      { time: 385, original_time: '00:06:25' }
+    ];
+    expect(hasZeroTimestamp(timestamps)).toBe(true);
+  });
+  
+  it('returns true when timestamps include 00:00', () => {
+    const timestamps = [
+      { time: 0, original_time: '00:00' },
+      { time: 385, original_time: '00:06:25' }
+    ];
+    expect(hasZeroTimestamp(timestamps)).toBe(true);
+  });
+  
+  it('returns true when timestamps include 0:00:00', () => {
+    const timestamps = [
+      { time: 0, original_time: '0:00:00' },
+      { time: 385, original_time: '00:06:25' }
+    ];
+    expect(hasZeroTimestamp(timestamps)).toBe(true);
+  });
+  
+  it('returns true when timestamps include 00:00:00', () => {
+    const timestamps = [
+      { time: 0, original_time: '00:00:00' },
+      { time: 385, original_time: '00:06:25' }
+    ];
+    expect(hasZeroTimestamp(timestamps)).toBe(true);
+  });
+  
+  it('returns false when no zero timestamp is present', () => {
+    const timestamps = [
+      { time: 385, original_time: '00:06:25' },
+      { time: 1238, original_time: '00:20:38' }
+    ];
+    expect(hasZeroTimestamp(timestamps)).toBe(false);
+  });
+  
+  it('returns false for empty timestamp array', () => {
+    const timestamps = [];
+    expect(hasZeroTimestamp(timestamps)).toBe(false);
+  });
+  
+  it('returns true when a timestamp has time=0 but different format', () => {
+    const timestamps = [
+      { time: 0, original_time: '0' }, // Not a standard format but time is 0
+      { time: 385, original_time: '00:06:25' }
+    ];
+    expect(hasZeroTimestamp(timestamps)).toBe(true);
+  });
+});

--- a/scripts/__tests__/unit/schemaValidation.test.js
+++ b/scripts/__tests__/unit/schemaValidation.test.js
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Get current directory
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Path to schema files
+const schemaDir = path.join(__dirname, '../../../schema');
+const videoSchemaPath = path.join(schemaDir, 'video.schema.json');
+
+describe('Schema Validation', () => {
+  let ajv;
+  let validateVideo;
+  
+  beforeEach(() => {
+    // Setup Ajv
+    ajv = new Ajv({ allErrors: true });
+    addFormats(ajv);
+    
+    // Load schema
+    const videoSchema = JSON.parse(fs.readFileSync(videoSchemaPath, 'utf8'));
+    validateVideo = ajv.compile(videoSchema);
+  });
+  
+  describe('Video Schema', () => {
+    it('validates a video with standard HH:MM:SS timestamps', () => {
+      const videoData = {
+        video_id: 'test1234567',
+        title: 'Test Video',
+        start_datetime: '2023-01-01T00:00:00Z',
+        thumbnail_url: 'https://example.com/thumbnail.jpg',
+        timestamps: [
+          {
+            time: 3600,
+            original_time: '01:00:00',
+            song_id: 'song1234567',
+            comment_source: 'description'
+          }
+        ]
+      };
+      
+      const valid = validateVideo(videoData);
+      expect(valid).toBe(true);
+    });
+    
+    it('validates a video with H:MM:SS timestamps', () => {
+      const videoData = {
+        video_id: 'test1234567',
+        title: 'Test Video',
+        start_datetime: '2023-01-01T00:00:00Z',
+        thumbnail_url: 'https://example.com/thumbnail.jpg',
+        timestamps: [
+          {
+            time: 3600,
+            original_time: '1:00:00',
+            song_id: 'song1234567',
+            comment_source: 'description'
+          }
+        ]
+      };
+      
+      const valid = validateVideo(videoData);
+      expect(valid).toBe(true);
+    });
+    
+    it('validates a video with MM:SS timestamps', () => {
+      const videoData = {
+        video_id: 'test1234567',
+        title: 'Test Video',
+        start_datetime: '2023-01-01T00:00:00Z',
+        thumbnail_url: 'https://example.com/thumbnail.jpg',
+        timestamps: [
+          {
+            time: 65,
+            original_time: '01:05',
+            song_id: 'song1234567',
+            comment_source: 'description'
+          }
+        ]
+      };
+      
+      const valid = validateVideo(videoData);
+      expect(valid).toBe(true);
+    });
+    
+    it('validates a video with M:SS timestamps', () => {
+      const videoData = {
+        video_id: 'test1234567',
+        title: 'Test Video',
+        start_datetime: '2023-01-01T00:00:00Z',
+        thumbnail_url: 'https://example.com/thumbnail.jpg',
+        timestamps: [
+          {
+            time: 65,
+            original_time: '1:05',
+            song_id: 'song1234567',
+            comment_source: 'description'
+          }
+        ]
+      };
+      
+      const valid = validateVideo(videoData);
+      expect(valid).toBe(true);
+    });
+    
+    it('rejects invalid timestamp formats', () => {
+      const videoData = {
+        video_id: 'test1234567',
+        title: 'Test Video',
+        start_datetime: '2023-01-01T00:00:00Z',
+        thumbnail_url: 'https://example.com/thumbnail.jpg',
+        timestamps: [
+          {
+            time: 65,
+            original_time: '1:5', // Invalid format (missing leading zero in seconds)
+            song_id: 'song1234567',
+            comment_source: 'description'
+          }
+        ]
+      };
+      
+      const valid = validateVideo(videoData);
+      expect(valid).toBe(false);
+    });
+    
+    it('rejects timestamps with invalid seconds (> 59)', () => {
+      const videoData = {
+        video_id: 'test1234567',
+        title: 'Test Video',
+        start_datetime: '2023-01-01T00:00:00Z',
+        thumbnail_url: 'https://example.com/thumbnail.jpg',
+        timestamps: [
+          {
+            time: 65,
+            original_time: '1:65', // Invalid seconds
+            song_id: 'song1234567',
+            comment_source: 'description'
+          }
+        ]
+      };
+      
+      const valid = validateVideo(videoData);
+      expect(valid).toBe(false);
+    });
+    
+    it('rejects timestamps with invalid minutes (> 59) in HH:MM:SS format', () => {
+      const videoData = {
+        video_id: 'test1234567',
+        title: 'Test Video',
+        start_datetime: '2023-01-01T00:00:00Z',
+        thumbnail_url: 'https://example.com/thumbnail.jpg',
+        timestamps: [
+          {
+            time: 65,
+            original_time: '01:65:00', // Invalid minutes
+            song_id: 'song1234567',
+            comment_source: 'description'
+          }
+        ]
+      };
+      
+      const valid = validateVideo(videoData);
+      expect(valid).toBe(false);
+    });
+  });
+});

--- a/scripts/__tests__/unit/schemaValidation.test.js
+++ b/scripts/__tests__/unit/schemaValidation.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
 import fs from 'fs';

--- a/scripts/__tests__/unit/timestampPrioritization.test.js
+++ b/scripts/__tests__/unit/timestampPrioritization.test.js
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { processVideo } from '../../updateVideoData.js';
+import * as fs from 'fs';
+
+// Mock dependencies
+vi.mock('../../generateId.js', () => ({
+  generateArtistId: vi.fn().mockReturnValue('mock-artist-id'),
+  generateSongId: vi.fn().mockReturnValue('mock-song-id')
+}));
+
+vi.mock('../../generateVideosList.js', () => ({
+  generateVideosList: vi.fn()
+}));
+
+// Mock fs functions
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn()
+}));
+
+vi.mock('path', () => ({
+  join: vi.fn((...args) => args.join('/')),
+  dirname: vi.fn()
+}));
+
+// Mock fetch for API calls
+global.fetch = vi.fn();
+
+describe('Timestamp Prioritization Logic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // Mock environment variables
+    process.env.YOUTUBE_API_KEY = 'mock-api-key';
+    
+    // Mock fetch responses
+    global.fetch.mockImplementation((url) => {
+      if (url.includes('videos?part=snippet')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            items: [{
+              snippet: {
+                title: 'Test Video',
+                description: '', // Will be set in individual tests
+                publishedAt: '2023-01-01T00:00:00Z',
+                thumbnails: {
+                  default: { url: 'https://example.com/thumbnail.jpg' }
+                }
+              }
+            }]
+          })
+        });
+      } else if (url.includes('commentThreads?part=snippet')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            items: [] // Will be set in individual tests
+          })
+        });
+      }
+      return Promise.reject(new Error(`Unhandled URL: ${url}`));
+    });
+  });
+  
+  it('prioritizes description timestamps when they include a 0:00 timestamp', async () => {
+    // Setup description with 0:00 timestamp
+    const description = `
+      00:00 イントロ
+      00:06:25 星を編む / seiza
+      00:20:38 トレモロ / RADWIMPS
+    `;
+    
+    // Setup comments with different timestamps
+    const comments = [{
+      snippet: {
+        topLevelComment: {
+          snippet: {
+            textDisplay: '00:05:00 別の曲 / 別のアーティスト',
+            publishedAt: '2023-01-01T00:00:00Z',
+            likeCount: 10
+          }
+        }
+      }
+    }];
+    
+    // Mock fetch to return our test data
+    global.fetch.mockImplementation((url) => {
+      if (url.includes('videos?part=snippet')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            items: [{
+              snippet: {
+                title: 'Test Video',
+                description: description,
+                publishedAt: '2023-01-01T00:00:00Z',
+                thumbnails: {
+                  default: { url: 'https://example.com/thumbnail.jpg' }
+                }
+              }
+            }]
+          })
+        });
+      } else if (url.includes('commentThreads?part=snippet')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            items: comments
+          })
+        });
+      }
+      return Promise.reject(new Error(`Unhandled URL: ${url}`));
+    });
+    
+    // Mock fs.writeFileSync to capture the written data
+    let capturedVideoData = null;
+    fs.writeFileSync.mockImplementation((path, data) => {
+      if (path.includes('test-video-id.json')) {
+        capturedVideoData = JSON.parse(data);
+      }
+    });
+    
+    // Process the video
+    await processVideo('test-video-id');
+    
+    // Verify that description timestamps were used
+    expect(capturedVideoData).not.toBeNull();
+    expect(capturedVideoData.timestamps.length).toBeGreaterThan(0);
+    expect(capturedVideoData.timestamps[0].comment_source).toBe('description');
+    expect(capturedVideoData.timestamps[0].original_time).toBe('00:00');
+    
+    // Also verify that the second timestamp is correct
+    expect(capturedVideoData.timestamps[1].comment_source).toBe('description');
+    expect(capturedVideoData.timestamps[1].original_time).toBe('00:06:25');
+  });
+  
+  it('prioritizes comment timestamps when description has timestamps but no 0:00 timestamp', async () => {
+    // Setup description with timestamps but no 0:00
+    const description = `
+      20:00 から新曲のプレミア公開があります
+      30:00 に生配信を開始します
+    `;
+    
+    // Setup comments with song timestamps
+    const comments = [{
+      snippet: {
+        topLevelComment: {
+          snippet: {
+            textDisplay: '00:06:25 星を編む / seiza\n00:20:38 トレモロ / RADWIMPS',
+            publishedAt: '2023-01-01T00:00:00Z',
+            likeCount: 10
+          }
+        }
+      }
+    }];
+    
+    // Mock fetch to return our test data
+    global.fetch.mockImplementation((url) => {
+      if (url.includes('videos?part=snippet')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            items: [{
+              snippet: {
+                title: 'Test Video',
+                description: description,
+                publishedAt: '2023-01-01T00:00:00Z',
+                thumbnails: {
+                  default: { url: 'https://example.com/thumbnail.jpg' }
+                }
+              }
+            }]
+          })
+        });
+      } else if (url.includes('commentThreads?part=snippet')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            items: comments
+          })
+        });
+      }
+      return Promise.reject(new Error(`Unhandled URL: ${url}`));
+    });
+    
+    // Mock fs.writeFileSync to capture the written data
+    let capturedVideoData = null;
+    fs.writeFileSync.mockImplementation((path, data) => {
+      if (path.includes('test-video-id.json')) {
+        capturedVideoData = JSON.parse(data);
+      }
+    });
+    
+    // Process the video
+    await processVideo('test-video-id');
+    
+    // Verify that comment timestamps were used
+    expect(capturedVideoData).not.toBeNull();
+    expect(capturedVideoData.timestamps.length).toBeGreaterThan(0);
+    expect(capturedVideoData.timestamps[0].comment_source).toBe('comment');
+    expect(capturedVideoData.timestamps[0].original_time).toBe('00:06:25');
+  });
+  
+  it('falls back to description timestamps when no comments have timestamps', async () => {
+    // Setup description with timestamps but no 0:00
+    const description = `
+      00:06:25 星を編む / seiza
+      00:20:38 トレモロ / RADWIMPS
+    `;
+    
+    // Setup comments with no timestamps
+    const comments = [{
+      snippet: {
+        topLevelComment: {
+          snippet: {
+            textDisplay: 'Great video!',
+            publishedAt: '2023-01-01T00:00:00Z',
+            likeCount: 10
+          }
+        }
+      }
+    }];
+    
+    // Mock fetch to return our test data
+    global.fetch.mockImplementation((url) => {
+      if (url.includes('videos?part=snippet')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            items: [{
+              snippet: {
+                title: 'Test Video',
+                description: description,
+                publishedAt: '2023-01-01T00:00:00Z',
+                thumbnails: {
+                  default: { url: 'https://example.com/thumbnail.jpg' }
+                }
+              }
+            }]
+          })
+        });
+      } else if (url.includes('commentThreads?part=snippet')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            items: comments
+          })
+        });
+      }
+      return Promise.reject(new Error(`Unhandled URL: ${url}`));
+    });
+    
+    // Mock fs.writeFileSync to capture the written data
+    let capturedVideoData = null;
+    fs.writeFileSync.mockImplementation((path, data) => {
+      if (path.includes('test-video-id.json')) {
+        capturedVideoData = JSON.parse(data);
+      }
+    });
+    
+    // Process the video
+    await processVideo('test-video-id');
+    
+    // Verify that description timestamps were used as fallback
+    expect(capturedVideoData).not.toBeNull();
+    expect(capturedVideoData.timestamps.length).toBeGreaterThan(0);
+    expect(capturedVideoData.timestamps[0].comment_source).toBe('comment');
+    expect(capturedVideoData.timestamps[0].original_time).toBe('00:06:25');
+  });
+});


### PR DESCRIPTION
- タイムスタンプのフォーマットに `M:SS` を追加する
- 摘要欄のタイムスタンプを優先するのは 0 秒時点を含む場合のみとする

YouTube の仕様上、摘要欄に 0 秒時点のタイムスタンプがある場合に動画へチャプターを追加できる。チャプターがある場合はそのタイムスタンプをコメントより優先したいが、チャプターがある場合のみとしたい（例えば `20:00 からプレミア公開あります` のようなテキストを弾きたい）。