### PR TITLE
fix date picker

### DIFF
--- a/src/components/ui/simple-date-picker.tsx
+++ b/src/components/ui/simple-date-picker.tsx
@@ -20,7 +20,15 @@ export function SimpleDatePicker({
   className,
 }: SimpleDatePickerProps) {
   const [open, setOpen] = React.useState(false)
+  const [displayedMonth, setDisplayedMonth] = React.useState<Date>(() => date || new Date());
   const containerRef = React.useRef<HTMLDivElement>(null)
+
+  React.useEffect(() => {
+    if (open) {
+      // When the calendar opens, reset displayedMonth to the currently selected date or today
+      setDisplayedMonth(date || new Date());
+    }
+  }, [open]); // Rerun when the popover open state changes
 
   const handleClickOutside = React.useCallback((event: MouseEvent) => {
     if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
@@ -69,22 +77,26 @@ export function SimpleDatePicker({
             <div className="flex justify-between items-center p-2">
               <button
                 onClick={() => {
-                  const prevMonth = new Date(date || new Date());
-                  prevMonth.setMonth(prevMonth.getMonth() - 1);
-                  setDate(prevMonth);
+                  setDisplayedMonth(current => {
+                    const newDisplayedMonth = new Date(current);
+                    newDisplayedMonth.setMonth(newDisplayedMonth.getMonth() - 1);
+                    return newDisplayedMonth;
+                  });
                 }}
                 className="p-1 rounded-md hover:bg-muted"
               >
                 <ChevronLeft className="h-4 w-4" />
               </button>
               <div className="text-sm font-medium">
-                {date ? format(date, "yyyy年MM月", { locale: ja }) : format(new Date(), "yyyy年MM月", { locale: ja })}
+                {format(displayedMonth, "yyyy年MM月", { locale: ja })}
               </div>
               <button
                 onClick={() => {
-                  const nextMonth = new Date(date || new Date());
-                  nextMonth.setMonth(nextMonth.getMonth() + 1);
-                  setDate(nextMonth);
+                  setDisplayedMonth(current => {
+                    const newDisplayedMonth = new Date(current);
+                    newDisplayedMonth.setMonth(newDisplayedMonth.getMonth() + 1);
+                    return newDisplayedMonth;
+                  });
                 }}
                 className="p-1 rounded-md hover:bg-muted"
               >
@@ -95,7 +107,8 @@ export function SimpleDatePicker({
               mode="single"
               selected={date}
               onSelect={handleSelect}
-              defaultMonth={date}
+              month={displayedMonth}
+              onMonthChange={setDisplayedMonth}
               locale={ja}
               className="[&_table]:mt-0"
               components={{


### PR DESCRIPTION
date picker の挙動を修正する。

## 背景

期待は以下の通り

* 矢印で月を移動し、日付を選択するとその選択した日付が from-to の日付欄に設定される
* 月の移動中は from-to の日付欄を操作しない

現状は以下の通り

* 矢印で月を移動し、日付を選択すると「選択した日 + 移動前にフォーカスされていた月」日付が from-to の日付欄に設定される（例えば2025年5月10日が現在とする。この時、date picker で2025年2月2日を選択すると「2025年5月2日」が from-to の日付欄に設定されてしまう）
* 月の移動中は from-to の日付欄が「選択中の日 + 移動中にフォーカスされている月」になっている（例えば2025年5月10日が現在とする。この時 from 欄の date picker で前月に移動すると from 欄に2025年4月10日が入る。ユーザーが確定するまではこの from 欄を変更したくない） 

## 修正前

https://github.com/user-attachments/assets/dce2de8a-dd47-4e0a-bb7e-69355b434d0e

## 修正後

https://github.com/user-attachments/assets/fb30a061-f211-4964-af3f-2174aa8761b5
